### PR TITLE
fix(website): fix demo website pages

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 let multipleHtmlPlugins = globSync("./src/**/index.html").map((path) => {
   return new HtmlWebpackPlugin({
     template: path,
-    filename: path.substring(6),
+    filename: path.substring(4),
   });
 });
 


### PR DESCRIPTION
the demo website was not rendering anymore. may have something to do with the globSync change. I only caught this after removing the dist folder.